### PR TITLE
Build product.json to display excluded nodes

### DIFF
--- a/main.py
+++ b/main.py
@@ -36,3 +36,12 @@ ica.save('out_dir/ica.fif',overwrite=True)
 plt.figure(1)
 ica.plot_components()
 plt.savefig(os.path.join('out_figs','ica.png'))
+
+# build product.json dictionary for brainlife message
+product = {}
+product['brainlife'] = []
+product['brainlife'].append({'type': 'info', "msg": "here are the excluded nodes: "+', '.join([ str(f) for f in ecg_indices ])})
+
+# save product.json
+with open('product.json','w') as prod_f:
+    json.dump(product,prod_f)


### PR DESCRIPTION
Lines 40-47 will build and output a product.json, intended to show the exclude nodes following preprocessing on brainlife.io following app completion.

Lines 40-43 build the product.json, which is a simple json dictionary with a key of "brainlife" as an empty list, with the message inside a dictionary appended. Currently, the node labels are added to the "here are the excluded nodes" string with a comma and space separator between the nodes. But this, and the preceding message, can be however you want it to be formatted as long as it will work with the string python datatype.

The remaining lines save it out to the current working directory.